### PR TITLE
Add simplified MeasureRuntime function

### DIFF
--- a/runstat/main.go
+++ b/runstat/main.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	//project library
 	"github.com/t1cg/util/logger"
 )
@@ -108,4 +109,24 @@ func (r *RunInfo) MeasureRuntime() {
 // SetEndTime function sets the end time of the run.
 func (r *RunInfo) SetEndTime(t time.Time) {
 	r.EndTime = t
+}
+
+// MeasureRuntime prints a string containing the runtime information. This call
+// should always be made as
+// 	defer runstat.MeasureRuntime(time.Now())
+//
+// If no name is provided, the logger will print out the name of the calling
+// function
+func MeasureRuntime(startTime time.Time, name ...string) {
+	endTime := time.Now()
+	var printName string
+
+	// Check if a name was provided, otherwise get name from trace
+	if name != nil {
+		printName = name[0]
+	} else {
+		printName = strings.Split(logger.GetFuncName(2), logger.SEPERATOR)[0]
+	}
+
+	logger.L.Perf.Printf("%v runtime[%v] on cpus[%d] ", strings.TrimSpace(printName), endTime.Sub(startTime), CPUCount)
 }

--- a/runstat/main_test.go
+++ b/runstat/main_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestMeasureRuntime(t *testing.T) {
+func TestRMeasureRuntime(t *testing.T) {
 
 	r := RunInfo{}
 	r.Name = "runstat test"
@@ -18,5 +18,12 @@ func TestMeasureRuntime(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	r.SetEndTime(time.Now())
+
+}
+
+func TestMeasureRuntime(t *testing.T) {
+
+	defer MeasureRuntime(time.Now())
+	time.Sleep(50 * time.Millisecond)
 
 }


### PR DESCRIPTION
This commit simplifies the use of the MeasureRuntime functionality by combining all necessary functionality into a single call. This commit makes use of the fact that when this function is called:

```
defer runstat.MeasureRuntime(time.Now())
```

time.Now() is calculated immediately, but the MeasureRuntime function is not processed until the parent function returns.

Previously, the MeasureRuntime functionality would be used like this:
```
func (db *DBInfo) Begin() *apperror.AppInfo {

	//get the caller and callee (if any) function names
	fname := logger.GetFuncName()

	//performance analysis - begin
	trace := &runstat.RunInfo{Name: fname, StartTime: time.Now()}
	defer trace.MeasureRuntime()

	//**business process - begin
	var err error
	db.Tx, err = db.Cnn.Begin()
	if err != nil {
		a := &apperror.AppInfo{Msg: err}
		a.LogError(a.Error("db.Begin()"))
		trace.SetEndTime(time.Now())
		return a
	}
	//**business process - end

	//performance analysis - end
	trace.SetEndTime(time.Now())

	return nil
}
```

With the addition of the MeasureRuntime function to the runstat package, this could be rewritten as:
```
func (db *DBInfo) Begin() *apperror.AppInfo {
         // Performance Analysis
	defer runstat.MeasureRuntime(time.Now())

	var err error
	db.Tx, err = db.Cnn.Begin()
	if err != nil {
		a := &apperror.AppInfo{Msg: err}
		a.LogError(a.Error("db.Begin()"))
		return a
	}

	return nil
}
```